### PR TITLE
#15 備品詳細ページ履歴

### DIFF
--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -3,12 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Models\Item;
+use App\Models\UsageHistory;
 
 class ItemController extends Controller
 {
     public function show(int $id)
     {
         $item = Item::where('id', $id)->with('category')->first();
-        return view('items.show', compact('item'));
+        $logs = UsageHistory::where('item_id', $id)->latest()->take(5)->get();
+        return view('items.show', compact('item', 'logs'));
     }
 }

--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -11,8 +11,8 @@ class ItemController extends Controller
     public function show(int $id)
     {
         $item = Item::where('id', $id)->with('category')->first();
-        $logs = UsageHistory::where('item_id', $id)->latest()->take(5)->get();
-        return view('items.show', compact('item', 'logs'));
+        $histories = UsageHistory::where('item_id', $id)->latest()->take(5)->get();
+        return view('items.show', compact('item', 'histories'));
     }
 
     public function search(Request $request)

--- a/web/app/Models/UsageHistory.php
+++ b/web/app/Models/UsageHistory.php
@@ -13,4 +13,9 @@ class UsageHistory extends Model
     {
         return $this->belongsTo(Item::class);
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/web/database/seeders/UsageHistorySeeder.php
+++ b/web/database/seeders/UsageHistorySeeder.php
@@ -21,7 +21,8 @@ class UsageHistorySeeder extends Seeder
                 'item_id' => 1,
                 'is_returned' => true,
                 'start_at' => "2022-09-01",
-                'return_at' => "2022-09-6",
+                'return_at' => "2022-09-06",
+                'created_at' => "2022-09-01",
             ],
             [
                 'user_id' => 1,
@@ -29,6 +30,7 @@ class UsageHistorySeeder extends Seeder
                 'is_returned' => false,
                 'start_at' => "2022-09-03",
                 'return_at' => "2022-09-14",
+                'created_at' => "2022-09-03",
             ],
             [
                 'user_id' => 1,
@@ -36,6 +38,7 @@ class UsageHistorySeeder extends Seeder
                 'is_returned' => false,
                 'start_at' => "2022-09-07",
                 'return_at' => "2022-09-14",
+                'created_at' => "2022-09-07",
             ],
             [
                 'user_id' => 2,
@@ -43,6 +46,39 @@ class UsageHistorySeeder extends Seeder
                 'is_returned' => true,
                 'start_at' => "2022-09-07",
                 'return_at' => "2022-09-14",
+                'created_at' => "2022-09-07",
+            ],
+            [
+                'user_id' => 3,
+                'item_id' => 1,
+                'is_returned' => true,
+                'start_at' => "2022-02-07",
+                'return_at' => "2022-02-14",
+                'created_at' => "2022-02-07",
+            ],
+            [
+                'user_id' => 3,
+                'item_id' => 1,
+                'is_returned' => true,
+                'start_at' => "2021-02-07",
+                'return_at' => "2021-02-14",
+                'created_at' => "2021-02-07",
+            ],
+            [
+                'user_id' => 2,
+                'item_id' => 1,
+                'is_returned' => true,
+                'start_at' => "2021-02-15",
+                'return_at' => "2021-02-22",
+                'created_at' => "2021-02-15",
+            ],
+            [
+                'user_id' => 2,
+                'item_id' => 1,
+                'is_returned' => true,
+                'start_at' => "2022-05-15",
+                'return_at' => "2022-05-22",
+                'created_at' => "2022-05-15",
             ],
         ];
 

--- a/web/database/seeders/UserSeeder.php
+++ b/web/database/seeders/UserSeeder.php
@@ -28,6 +28,12 @@ class UserSeeder extends Seeder
                 'password' => bcrypt('password'),
                 'is_admin' => true,
             ],
+            [
+                'name' => 'しゅん',
+                'email' => 'user@com',
+                'password' => bcrypt('password'),
+                'is_admin' => false,
+            ],
         ];
 
         User::insert($data);

--- a/web/resources/views/items/show.blade.php
+++ b/web/resources/views/items/show.blade.php
@@ -17,15 +17,11 @@
                             <div class="flex items-center">
                                 <input
                                     class="inlin-block text-sm rounded-lg border border-gray-300 cursor-pointer focus:outline-none"
-                                    name="start_date"
-                                    type="date"
-                                >
+                                    name="start_date" type="date">
                                 <span class="px-2">〜</span>
                                 <input
                                     class="inlin-block text-sm rounded-lg border border-gray-300 cursor-pointer focus:outline-none"
-                                    name="end_date"
-                                    type="date"
-                                >
+                                    name="end_date" type="date">
                             </div>
                         </div>
                         <div class="py-4">
@@ -37,6 +33,8 @@
         </div>
         <div>
             <h3 class="PHeading3 border-l-4 p-2 border-blue-500">履歴</h3>
+            @foreach ($logs as $log)
+            @endforeach
         </div>
         <div>
             <h3 class="PHeading3 border-l-4 p-2 border-blue-500">情報</h3>

--- a/web/resources/views/items/show.blade.php
+++ b/web/resources/views/items/show.blade.php
@@ -37,8 +37,22 @@
         </div>
         <div>
             <h3 class="PHeading3 border-l-4 p-2 border-blue-500">履歴</h3>
-            @foreach ($logs as $log)
-            @endforeach
+            <table class="w-full">
+                <tbody>
+                    @foreach ($histories as $history)
+                        <tr class="border-y-2">
+                            <td class="px-4 py-6 font-bold w-max whitespace-nowrap">
+                                @if ($history->is_returned)
+                                    返却済み
+                                @endif
+                            </td>
+                            <td class="px-4 py-6 whitespace-nowrap">{{ $history->start_at }}~{{ $history->return_at }}
+                            </td>
+                            <td class="px-4 py-6">{{ $history->user->name }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
         </div>
         <div>
             <h3 class="PHeading3 border-l-4 p-2 border-blue-500">情報</h3>


### PR DESCRIPTION
## 関連イシュー
#15

## 🚨🚨🚨🚨🚨追加実装🚨🚨🚨🚨🚨
利用状況の記入ができていなかったため、以下のプルリクで実装しました。
https://github.com/posse-ap/posse1-hackathon-202209-team1A/pull/75

## 検証したこと
- ５個以上借りたレコードがある時、５個までが表示される。
- 最新順に表示されている。(created_atのカラムを参照)

## エビデンス
データが５件以上の時、2021-02-07に作成された古いレコードが表示されていない
<img width="338" alt="スクリーンショット 2022-09-07 16 41 33" src="https://user-images.githubusercontent.com/74808471/188818906-72c9af05-56d7-4240-8b8e-01a939b89164.png">

<img width="1264" alt="スクリーンショット 2022-09-07 16 37 44" src="https://user-images.githubusercontent.com/74808471/188818063-c532ac26-50da-4556-8a45-9dcf027bb133.png">

返却されていないとき
<img width="1222" alt="スクリーンショット 2022-09-07 16 49 27" src="https://user-images.githubusercontent.com/74808471/188820842-9c6d5a98-5a6a-4a13-a0a0-d333e195b994.png">

