### PR TITLE
#19 用意されたキーワードで検索可能

### DIFF
--- a/web/public/css/app.css
+++ b/web/public/css/app.css
@@ -874,6 +874,9 @@ select {
 .-mr-2 {
   margin-right: -0.5rem;
 }
+.mr-3 {
+  margin-right: 0.75rem;
+}
 .block {
   display: block;
 }

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -18,6 +18,13 @@
                     </div>
                 </div>
             </form>
+            <div class="flex text-white whitespace-nowrap mt-4">
+                <p>キーワード：</p>
+                <a href="{{ route('items.result', ['keyword' => "Go言語"]) }}" class="block mr-3">Go言語</a>
+                <a href="{{ route('items.result', ['keyword' => "Rust"]) }}" class="block mr-3">Rust</a>
+                <a href="{{ route('items.result', ['keyword' => "スクラム"]) }}" class="block mr-3">スクラム</a>
+                <a href="{{ route('items.result', ['keyword' => "Laravel"]) }}" class="block mr-3">Laravel</a>
+            </div>
         </div>
     </div>
     <div class="h-full px-8 sm:px-12 lg:px-24">


### PR DESCRIPTION
## 関連イシュー
#19 

## 検証したこと
・ダッシュボード　検索ボックスの下に用意されたキーワードで検索できるか確認しました
・用意されたキーワードが、遷移先の検索ボックスに表示されているか確認しました

## エビデンス
・ダッシュボード
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/74804252/188820555-1114dc07-bc7a-4e5e-a06c-096d4205d8af.png">

・「Go言語」をクリック時
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/188820664-ff26484e-e4ba-424e-b724-607719224c31.png">

・「Rust」をクリック時
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189139096-85689c61-1799-4cb0-beae-700c89c9c82b.png">