### PR TITLE
#10 備品一覧 Issue4 公開設定されている備品のみ表示

### DIFF
--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -10,7 +10,10 @@ class ItemController extends Controller
 {
     public function show(int $id)
     {
-        $item = Item::where('id', $id)->with('category')->first();
+        $item = Item::find($id);
+        if (!$item->is_public) { 
+            abort(404); 
+        }
         $histories = UsageHistory::where('item_id', $id)->latest()->take(5)->get();
         return view('items.show', compact('item', 'histories'));
     }

--- a/web/app/Models/Category.php
+++ b/web/app/Models/Category.php
@@ -26,12 +26,12 @@ class Category extends Model
         $categories = self::with('items')->get();
 
         return $categories->filter(function ($value, $key) {
-            return count($value->items->where('is_public', 1)) > 0;
+            return count($value->items->where('is_public', true)) > 0;
         });
     }
 
     public function items()
     {
-        return $this->hasMany(Item::class)->where('is_public', 1);
+        return $this->hasMany(Item::class)->where('is_public', true);
     }
 }

--- a/web/app/Models/Category.php
+++ b/web/app/Models/Category.php
@@ -26,12 +26,12 @@ class Category extends Model
         $categories = self::with('items')->get();
 
         return $categories->filter(function ($value, $key) {
-            return count($value->items) > 0;
+            return count($value->items->where('is_public', 1)) > 0;
         });
     }
 
     public function items()
     {
-        return $this->hasMany(Item::class);
+        return $this->hasMany(Item::class)->where('is_public', 1);
     }
 }

--- a/web/app/Models/Item.php
+++ b/web/app/Models/Item.php
@@ -39,6 +39,11 @@ class Item extends Model
         return UsageHistory::where('item_id', $this->id)->where('is_returned', false)->exists();
     }
 
+    public function is_available()
+    {
+        return UsageHistory::where('item_id', $this->id)->where('is_returned', true)->exists();
+    }
+
     public function am_borrowing()
     {
         return UsageHistory::where('item_id', $this->id)->where('is_returned', false)->where('user_id', Auth::id())->exists();

--- a/web/app/Models/Item.php
+++ b/web/app/Models/Item.php
@@ -24,7 +24,7 @@ class Item extends Model
      */
     public static function latestItems(): Collection
     {
-        return self::whereDate('created_at', '>=', Carbon::now()->subDays(self::LATEST_ITEMS_DAYS))
+        return self::where('is_public', 1)->whereDate('created_at', '>=', Carbon::now()->subDays(self::LATEST_ITEMS_DAYS))
             ->with('category')
             ->get();
     }
@@ -58,4 +58,14 @@ class Item extends Model
     {
         return UsageHistory::where('item_id', $this->id)->where('is_returned', false)->first();
     }
+
+    // public function is_public()
+    // {
+    //     return 1;
+    // }
+
+    // public function is_hidden()
+    // {
+    //     return 0;
+    // }
 }

--- a/web/app/Models/Item.php
+++ b/web/app/Models/Item.php
@@ -24,7 +24,7 @@ class Item extends Model
      */
     public static function latestItems(): Collection
     {
-        return self::where('is_public', 1)->whereDate('created_at', '>=', Carbon::now()->subDays(self::LATEST_ITEMS_DAYS))
+        return self::where('is_public', true)->whereDate('created_at', '>=', Carbon::now()->subDays(self::LATEST_ITEMS_DAYS))
             ->with('category')
             ->get();
     }
@@ -53,14 +53,4 @@ class Item extends Model
     {
         return UsageHistory::where('item_id', $this->id)->where('is_returned', false)->first();
     }
-
-    // public function is_public()
-    // {
-    //     return 1;
-    // }
-
-    // public function is_hidden()
-    // {
-    //     return 0;
-    // }
 }


### PR DESCRIPTION
## 関連イシュー
[# 10](https://github.com/posse-ap/posse1-hackathon-202209-team1A/issues/10)

公開設定されている備品のみ表示されていること
- [x] ダッシュボード
- [x]  備品一覧の一覧取得時　
　　に公開設定で絞り込みがされること
- [x] 備品詳細画面は公開されていない場合は404が返却されること

## 検証したこと
- is_publicの値がnullの場合、ダッシュボードには表示されない
- is_publicの値がnullの場合、備品詳細画面を閲覧しようとしても404エラーが返されること

## エビデンス
<img width="1383" alt="スクリーンショット 2022-09-07 21 52 53" src="https://user-images.githubusercontent.com/74807901/188883147-237b92a8-4322-4b73-9832-5a3a864a4f30.png">
→の場合　id=5のitemsの 備品詳細画面404が返却される
<img width="1087" alt="スクリーンショット 2022-09-07 21 56 03" src="https://user-images.githubusercontent.com/74807901/188883595-34bf2578-9884-4554-b08b-9cf20b454d32.png">

<img width="594" alt="スクリーンショット 2022-09-07 22 00 37" src="https://user-images.githubusercontent.com/74807901/188884456-110aca86-f57d-43af-b040-6037ccde2c89.png">
