### PR TITLE
#24 ダッシュボード Issue5 備品を左寄せで表示する（デザイン修正)

### DIFF
--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -30,7 +30,7 @@
     <div class="h-full px-8 sm:px-12 lg:px-24">
         <div class="py-12 text-center">
             <h2 class="text-2xl font-bold py-6">新着</h2>
-            <div class="flex justify-center py-4">
+            <div class="flex py-4">
                 @foreach ($latestItems as $key => $item)
                     @if ($key < $displayLimit)
                         <x-item-card :item="$item"></x-item-card>
@@ -51,7 +51,7 @@
         @foreach ($categoryItems as $category)
             <div class="py-12 text-center">
                 <h2 class="text-2xl font-bold py-6">{{ $category->name }}</h2>
-                <div class="flex justify-center py-4">
+                <div class="flex py-4">
                     @foreach ($category->items as $key => $item)
                         @if ($key < $displayLimit)
                             <x-item-card :item="$item"></x-item-card>


### PR DESCRIPTION
## 関連イシュー
#24 

## 検証したこと
- カテゴリの要素が1つの時の左寄せの見た目を確認
- カテゴリの要素が3つの時の左寄せの見た目を確認

## エビデンス
<img width="790" alt="スクリーンショット 2022-09-08 1 32 09" src="https://user-images.githubusercontent.com/74807901/188931830-d10c8824-a777-4c75-bf47-06df3b5eb017.png">

