### PR TITLE
#20 すべて見る機能作成

### DIFF
--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Category;
 use App\Models\Item;
 use App\Models\UsageHistory;
 use Illuminate\Http\Request;
@@ -29,7 +30,6 @@ class ItemController extends Controller
     {
         $items = Item::paginate(20);
         $query = Item::query();
-        $displayLimit = 4;
 
         if ($keyword) {
 
@@ -41,11 +41,29 @@ class ItemController extends Controller
 
             // 単語をループで回し、ユーザーネームと部分一致するものがあれば、$queryとして保持される
             foreach ($wordArraySearched as $value) {
-                $query->where('name', 'like', '%' . $value . '%');
+                $query->where('is_public', true)->where('name', 'like', '%' . $value . '%');
             }
 
             $items = $query->paginate(20);
         }
-        return view('items.search', compact('displayLimit', 'items', 'keyword'));
+        return view('items.search', compact('items', 'keyword'));
+    }
+
+    public function categoryList($categoryId)
+    {
+        $items = Item::where('category_id', $categoryId)->where('is_public', true)->paginate(20);
+        $categoryName = Category::find($categoryId)->name;
+        $keyword = null;
+
+        return view('items.search', compact('items', 'categoryName', 'keyword'));
+    }
+
+    public function latestList()
+    {
+        $items = Item::where('is_public', true)->orderBy('created_at', 'desc')->paginate(20);
+        $categoryName = "新着";
+        $keyword = null;
+
+        return view('items.search', compact('items', 'categoryName', 'keyword'));
     }
 }

--- a/web/public/css/app.css
+++ b/web/public/css/app.css
@@ -757,6 +757,9 @@ select {
   line-height: 1.75rem;
   font-weight: 700;
 }
+.fixed {
+  position: fixed;
+}
 .absolute {
   position: absolute;
 }
@@ -772,11 +775,14 @@ select {
 .left-2 {
   left: 0.5rem;
 }
-.left-0 {
-  left: 0px;
+.top-0 {
+  top: 0px;
 }
 .right-0 {
   right: 0px;
+}
+.left-0 {
+  left: 0px;
 }
 .z-0 {
   z-index: 0;
@@ -802,29 +808,41 @@ select {
 .-ml-px {
   margin-left: -1px;
 }
+.mt-8 {
+  margin-top: 2rem;
+}
+.mb-12 {
+  margin-bottom: 3rem;
+}
+.mr-4 {
+  margin-right: 1rem;
+}
+.ml-6 {
+  margin-left: 1.5rem;
+}
 .mt-20 {
   margin-top: 5rem;
 }
-.mt-8 {
-  margin-top: 2rem;
+.mb-4 {
+  margin-bottom: 1rem;
+}
+.mb-10 {
+  margin-bottom: 2.5rem;
+}
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+.mr-8 {
+  margin-right: 2rem;
+}
+.ml-2 {
+  margin-left: 0.5rem;
 }
 .mt-4 {
   margin-top: 1rem;
 }
 .mt-6 {
   margin-top: 1.5rem;
-}
-.mb-12 {
-  margin-bottom: 3rem;
-}
-.mb-2 {
-  margin-bottom: 0.5rem;
-}
-.mb-4 {
-  margin-bottom: 1rem;
-}
-.ml-2 {
-  margin-left: 0.5rem;
 }
 .mb-8 {
   margin-bottom: 2rem;
@@ -838,35 +856,26 @@ select {
 .ml-12 {
   margin-left: 3rem;
 }
-.mr-3 {
-  margin-right: 0.75rem;
-}
-.mt-1 {
-  margin-top: 0.25rem;
+.ml-1 {
+  margin-left: 0.25rem;
 }
 .mt-2 {
   margin-top: 0.5rem;
 }
-.ml-1 {
-  margin-left: 0.25rem;
+.mr-2 {
+  margin-right: 0.5rem;
 }
-.-mr-2 {
-  margin-right: -0.5rem;
+.ml-4 {
+  margin-left: 1rem;
 }
-.ml-6 {
-  margin-left: 1.5rem;
+.-mt-px {
+  margin-top: -1px;
 }
 .mt-1 {
   margin-top: 0.25rem;
 }
-.mb-10 {
-  margin-bottom: 2.5rem;
-}
-.mr-8 {
-  margin-right: 2rem;
-}
-.mr-4 {
-  margin-right: 1rem;
+.-mr-2 {
+  margin-right: -0.5rem;
 }
 .block {
   display: block;
@@ -913,20 +922,14 @@ select {
 .h-8 {
   height: 2rem;
 }
-.h-6 {
-  height: 1.5rem;
-}
 .h-20 {
   height: 5rem;
-}
-.h-16 {
-  height: 4rem;
 }
 .h-10 {
   height: 2.5rem;
 }
-.h-4 {
-  height: 1rem;
+.min-h-screen {
+  min-height: 100vh;
 }
 .w-5 {
   width: 1.25rem;
@@ -934,8 +937,26 @@ select {
 .w-full {
   width: 100%;
 }
+.w-20 {
+  width: 5rem;
+}
+.w-48 {
+  width: 12rem;
+}
+.w-24 {
+  width: 6rem;
+}
+.w-32 {
+  width: 8rem;
+}
+.w-60 {
+  width: 15rem;
+}
 .w-96 {
   width: 24rem;
+}
+.w-4 {
+  width: 1rem;
 }
 .w-80 {
   width: 20rem;
@@ -948,26 +969,17 @@ select {
 .w-6 {
   width: 1.5rem;
 }
-.w-48 {
-  width: 12rem;
+.w-8 {
+  width: 2rem;
 }
 .w-auto {
   width: auto;
 }
-.w-4 {
-  width: 1rem;
+.max-w-xl {
+  max-width: 36rem;
 }
-.w-20 {
-  width: 5rem;
-}
-.w-24 {
-  width: 6rem;
-}
-.w-32 {
-  width: 8rem;
-}
-.w-60 {
-  width: 15rem;
+.max-w-6xl {
+  max-width: 72rem;
 }
 .max-w-7xl {
   max-width: 80rem;
@@ -1035,6 +1047,9 @@ select {
 .flex-col {
   flex-direction: column;
 }
+.flex-wrap {
+  flex-wrap: wrap;
+}
 .items-end {
   align-items: flex-end;
 }
@@ -1078,11 +1093,11 @@ select {
 .rounded-md {
   border-radius: 0.375rem;
 }
-.rounded-lg {
-  border-radius: 0.5rem;
-}
 .rounded {
   border-radius: 0.25rem;
+}
+.rounded-lg {
+  border-radius: 0.5rem;
 }
 .rounded-l-md {
   border-top-left-radius: 0.375rem;
@@ -1105,11 +1120,14 @@ select {
 .border-l-4 {
   border-left-width: 4px;
 }
-.border-b {
-  border-bottom-width: 1px;
-}
 .border-t {
   border-top-width: 1px;
+}
+.border-r {
+  border-right-width: 1px;
+}
+.border-b {
+  border-bottom-width: 1px;
 }
 .border-gray-300 {
   --tw-border-opacity: 1;
@@ -1134,13 +1152,17 @@ select {
 .border-transparent {
   border-color: transparent;
 }
-.border-gray-100 {
-  --tw-border-opacity: 1;
-  border-color: rgb(243 244 246 / var(--tw-border-opacity));
-}
 .border-gray-200 {
   --tw-border-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
+}
+.border-gray-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity));
+}
+.border-gray-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity));
 }
 .bg-white {
   --tw-bg-opacity: 1;
@@ -1185,6 +1207,9 @@ select {
 .p-2 {
   padding: 0.5rem;
 }
+.p-6 {
+  padding: 1.5rem;
+}
 .px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
@@ -1217,10 +1242,6 @@ select {
   padding-left: 0px;
   padding-right: 0px;
 }
-.py-6 {
-  padding-top: 1.5rem;
-  padding-bottom: 1.5rem;
-}
 .py-4 {
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -1229,17 +1250,9 @@ select {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
 }
-.px-3 {
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-}
 .px-20 {
   padding-left: 5rem;
   padding-right: 5rem;
-}
-.px-8 {
-  padding-left: 2rem;
-  padding-right: 2rem;
 }
 .py-12 {
   padding-top: 3rem;
@@ -1306,6 +1319,10 @@ select {
   font-size: 0.875rem;
   line-height: 1.25rem;
 }
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
 .text-xs {
   font-size: 0.75rem;
   line-height: 1rem;
@@ -1314,10 +1331,6 @@ select {
   font-size: 1.125rem;
   line-height: 1.75rem;
 }
-.text-2xl {
-  font-size: 1.5rem;
-  line-height: 2rem;
-}
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
@@ -1325,10 +1338,6 @@ select {
 .text-base {
   font-size: 1rem;
   line-height: 1.5rem;
-}
-.text-lg {
-  font-size: 1.125rem;
-  line-height: 1.75rem;
 }
 .font-medium {
   font-weight: 500;
@@ -1351,11 +1360,17 @@ select {
 .leading-tight {
   line-height: 1.25;
 }
-.tracking-widest {
-  letter-spacing: 0.1em;
+.leading-7 {
+  line-height: 1.75rem;
 }
 .tracking-wide {
   letter-spacing: 0.025em;
+}
+.tracking-wider {
+  letter-spacing: 0.05em;
+}
+.tracking-widest {
+  letter-spacing: 0.1em;
 }
 .text-gray-500 {
   --tw-text-opacity: 1;
@@ -1401,29 +1416,37 @@ select {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
 }
-.text-indigo-700 {
+.text-gray-200 {
   --tw-text-opacity: 1;
-  color: rgb(67 56 202 / var(--tw-text-opacity));
+  color: rgb(229 231 235 / var(--tw-text-opacity));
 }
-.text-lime-800 {
+.text-gray-300 {
   --tw-text-opacity: 1;
-  color: rgb(63 98 18 / var(--tw-text-opacity));
+  color: rgb(209 213 219 / var(--tw-text-opacity));
 }
 .text-gray-400 {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
 }
+.text-indigo-700 {
+  --tw-text-opacity: 1;
+  color: rgb(67 56 202 / var(--tw-text-opacity));
+}
 .text-gray-800 {
   --tw-text-opacity: 1;
   color: rgb(31 41 55 / var(--tw-text-opacity));
 }
-.text-red-500 {
-  --tw-text-opacity: 1;
-  color: rgb(239 68 68 / var(--tw-text-opacity));
-}
 .text-blue-600 {
   --tw-text-opacity: 1;
   color: rgb(37 99 235 / var(--tw-text-opacity));
+}
+.text-green-400 {
+  --tw-text-opacity: 1;
+  color: rgb(74 222 128 / var(--tw-text-opacity));
+}
+.text-red-400 {
+  --tw-text-opacity: 1;
+  color: rgb(248 113 113 / var(--tw-text-opacity));
 }
 .underline {
   -webkit-text-decoration-line: underline;
@@ -1657,6 +1680,14 @@ select {
   opacity: 0.25;
 }
 
+@media (prefers-color-scheme: dark) {
+
+  .dark\:bg-gray-900 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(17 24 39 / var(--tw-bg-opacity));
+  }
+}
+
 @media (min-width: 640px) {
 
   .sm\:-my-px {
@@ -1694,6 +1725,10 @@ select {
 
   .sm\:items-center {
     align-items: center;
+  }
+
+  .sm\:justify-start {
+    justify-content: flex-start;
   }
 
   .sm\:justify-center {

--- a/web/resources/views/components/item-card.blade.php
+++ b/web/resources/views/components/item-card.blade.php
@@ -1,14 +1,14 @@
 <div class="text-left mx-4" style="width: 300px;">
-    <p class="h-6 font-bold">
+    <p class="h-6 font-bold w-full">
         @if ($item->is_borrowed())
             {{ $item->latestUsageHistory()->user->name }}さんが利用中（〜{{ $item->latestUsageHistory()->return_at }}）
         @endif
     </p>
-    <div class="bg-slate-100">
+    <div class="bg-slate-100 w-full">
         <a href="{{ route('items.show', ['id' => $item->id]) }}">
             <img class="object-contain h-48 w-96" src="{{ \Storage::url($item->image_path) }}">
         </a>
     </div>
-    <p class="font-bold py-2">{{ $item->category->name ?? '' }}</p>
-    <p>{{ $item->name }}</p>
+    <p class="font-bold py-2 w-full">{{ $item->category->name ?? '' }}</p>
+    <p class="w-full">{{ $item->name }}</p>
 </div>

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -38,7 +38,7 @@
                 @endforeach
             </div>
             <div>
-                <a href="/"
+                <a href="{{ route('items.latestList') }}"
                     class="inline-block bg-transparent hover:bg-gray-100 text-gray-500 font-semibold py-2 px-6 border border-gray-500 rounded">
                     <div class="flex items-center">
                         <span class="px-2">すべて見る</span>
@@ -59,7 +59,7 @@
                     @endforeach
                 </div>
                 <div>
-                    <a href="/"
+                    <a href="{{ route('items.categoryList', ['categoryId' => $category->id]) }}"
                         class="inline-block bg-transparent hover:bg-gray-100 text-gray-500 font-semibold py-2 px-6 border border-gray-500 rounded">
                         <div class="flex items-center">
                             <span class="px-2">すべて見る</span>

--- a/web/resources/views/items/search.blade.php
+++ b/web/resources/views/items/search.blade.php
@@ -2,16 +2,14 @@
 
     <div class="grid grid-cols-1 gap-8 mt-8 px-0 md:px-32">
         <div>
-            <h1 class="PHeading3 border-l-4 p-2 border-blue-500">備品一覧</h1>
+            <h1 class="PHeading3 border-l-4 p-2 border-blue-500">「@if (isset($keyword)){{ $keyword }}@else{{ $categoryName }}@endif」の備品一覧</h1>
         </div>
         <h2><span class="font-bold">{{ $items->total() }}</span>件見つかりました</h2>
     </div>
     <div class="h-full px-8 sm:px-12 lg:px-24">
-        <div class="flex py-4">
+        <div class="flex py-4 flex-wrap">
             @foreach ($items as $key => $item)
-                @if ($key < $displayLimit)
-                    <x-item-card :item="$item"></x-item-card>
-                @endif
+                <x-item-card :item="$item"></x-item-card>
             @endforeach
         </div>
     </div>

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -52,6 +52,8 @@ Route::middleware(['auth'])->group(function () {
 
 Route::prefix('items')->group(function () {
     Route::get('search/{keyword?}', [ItemController::class, 'result'])->name('items.result');
+    Route::get('category/{categoryId?}', [ItemController::class, 'categoryList'])->name('items.categoryList');
+    Route::get('latest/list', [ItemController::class, 'latestList'])->name('items.latestList');
 });
 
 Route::get('/', [DashboardController::class, 'index'])->name('dashboard');


### PR DESCRIPTION
## 関連イシュー
#20 

## 🚨🚨🚨🚨🚨追加実装の方で動きはご確認ください🚨🚨🚨🚨🚨
[こちらのプルリク](https://github.com/posse-ap/posse1-hackathon-202209-team1A/pull/67)で、新着の条件式（直近30日以内）を追加しました

## 検証したこと
- 「新着」の全て見るをクリックした時に、30日以内に登録された新着順に全ての備品が表示されるか
- それぞれのカテゴリーをクリックした時に、それぞれのカテゴリーの全ての備品が表示されるか
- 「XX」の備品一覧というように、カテゴリー名や新着、キーワードの名前が表示されるか
- is_publicがfalseの備品が間違って表示されないか

## エビデンス
- 新着のもっと見るを押下時
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/188939342-d58b9a90-282e-40c9-8704-f25b8cf40524.png">

- 「書籍：技術書」カテゴリーのもっと見るを押下時
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/74804252/188939717-ab279993-4925-4625-95ba-ac00a4c96b89.png">


