### PR TITLE
#8 新着時のフィルタ機能実装

### DIFF
--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -58,12 +58,47 @@ class ItemController extends Controller
         return view('items.search', compact('items', 'categoryName', 'keyword'));
     }
 
-    public function latestList()
+    public function latestList($categoryId, $availableId)
     {
         $items = Item::where('is_public', true)->orderBy('created_at', 'desc')->paginate(20);
         $categoryName = "新着";
         $keyword = null;
+        $categories = Category::all();
 
-        return view('items.search', compact('items', 'categoryName', 'keyword'));
+        if($categoryId != 0) {
+            if($availableId == 0) {
+                $items = Item::where('is_public', true)->where('category_id', $categoryId)->orderBy('created_at', 'desc')->paginate(20);
+            } elseif ($availableId == 1) {
+                $items = Item::where('is_public', true)->where('category_id', $categoryId)->whereDoesntHave('usageHistories', function($query)
+                {
+                    $query->where('is_returned', false);
+                })
+                ->orderBy('created_at', 'desc')->paginate(20);
+            } else {
+                $items = Item::where('is_public', true)->where('category_id', $categoryId)->whereHas('usageHistories', function($query)
+                {
+                    $query->where('is_returned', false);
+                })
+                ->orderBy('created_at', 'desc')->paginate(20);
+            }
+        } else {
+            if($availableId == 0) {
+                $items = Item::where('is_public', true)->paginate(20);
+            } elseif ($availableId == 1) {
+                $items = Item::where('is_public', true)->whereDoesntHave('usageHistories', function($query)
+                {
+                    $query->where('is_returned', false);
+                })
+                ->orderBy('created_at', 'desc')->paginate(20);
+            } else {
+                $items = Item::where('is_public', true)->whereHas('usageHistories', function($query)
+                {
+                    $query->where('is_returned', false);
+                })
+                ->orderBy('created_at', 'desc')->paginate(20);
+            }
+        }
+
+        return view('items.search', compact('items', 'categoryName', 'keyword', 'categories', 'categoryId', 'availableId'));
     }
 }

--- a/web/public/css/app.css
+++ b/web/public/css/app.css
@@ -877,6 +877,12 @@ select {
 .-mr-2 {
   margin-right: -0.5rem;
 }
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
 .block {
   display: block;
 }
@@ -1258,6 +1264,10 @@ select {
   padding-top: 3rem;
   padding-bottom: 3rem;
 }
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
 .px-1 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
@@ -1265,10 +1275,6 @@ select {
 .py-1 {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
-}
-.py-8 {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
 }
 .pt-8 {
   padding-top: 2rem;
@@ -1392,6 +1398,10 @@ select {
   --tw-text-opacity: 1;
   color: rgb(63 98 18 / var(--tw-text-opacity));
 }
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity));
+}
 .text-blue-800 {
   --tw-text-opacity: 1;
   color: rgb(30 64 175 / var(--tw-text-opacity));
@@ -1407,10 +1417,6 @@ select {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-.text-red-600 {
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity));
 }
 .text-gray-900 {
   --tw-text-opacity: 1;
@@ -1439,14 +1445,6 @@ select {
 .text-blue-600 {
   --tw-text-opacity: 1;
   color: rgb(37 99 235 / var(--tw-text-opacity));
-}
-.text-green-400 {
-  --tw-text-opacity: 1;
-  color: rgb(74 222 128 / var(--tw-text-opacity));
-}
-.text-red-400 {
-  --tw-text-opacity: 1;
-  color: rgb(248 113 113 / var(--tw-text-opacity));
 }
 .underline {
   -webkit-text-decoration-line: underline;
@@ -1524,7 +1522,29 @@ select {
 }
 
 .bg-applied-use {
-    background-color: #D6E6DD;
+    background-color: #d6e6dd;
+}
+
+.PButton-primary-mini {
+    border-radius: 9999px;
+    --tw-bg-opacity: 1;
+    background-color: rgb(250 204 21 / var(--tw-bg-opacity));
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    font-weight: 700;
+}
+
+.PButton-gray-mini {
+    border-radius: 9999px;
+    --tw-bg-opacity: 1;
+    background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    font-weight: 700;
 }
 
 .hover\:border-gray-300:hover {

--- a/web/resources/css/app.css
+++ b/web/resources/css/app.css
@@ -4,27 +4,27 @@
 
 @layer components {
     .PButton-primary {
-        @apply bg-yellow-400 font-bold py-3 px-8 rounded-full
+        @apply bg-yellow-400 font-bold py-3 px-8 rounded-full;
     }
 
     .PButton-primary:hover {
-        @apply bg-yellow-300
+        @apply bg-yellow-300;
     }
 
     .PButton-disabled {
-        @apply bg-gray-200 font-bold py-3 px-8 rounded-full text-white
+        @apply bg-gray-200 font-bold py-3 px-8 rounded-full text-white;
     }
 
     .PButton-red {
-        @apply bg-red-700 font-bold text-white py-3 px-8 rounded-full
+        @apply bg-red-700 font-bold text-white py-3 px-8 rounded-full;
     }
 
     .PButton-red:hover {
-        @apply bg-red-500
+        @apply bg-red-500;
     }
 
     .PHeading3 {
-        @apply text-xl font-bold
+        @apply text-xl font-bold;
     }
 }
 
@@ -33,5 +33,27 @@
 }
 
 .bg-applied-use {
-    background-color: #D6E6DD;
+    background-color: #d6e6dd;
+}
+
+.PButton-primary-mini {
+    border-radius: 9999px;
+    --tw-bg-opacity: 1;
+    background-color: rgb(250 204 21 / var(--tw-bg-opacity));
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    font-weight: 700;
+}
+
+.PButton-gray-mini {
+    border-radius: 9999px;
+    --tw-bg-opacity: 1;
+    background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    font-weight: 700;
 }

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -38,7 +38,7 @@
                 @endforeach
             </div>
             <div>
-                <a href="{{ route('items.latestList') }}"
+                <a href="{{ route('items.latestList', ['categoryId' => 0, 'availableId' => 0]) }}"
                     class="inline-block bg-transparent hover:bg-gray-100 text-gray-500 font-semibold py-2 px-6 border border-gray-500 rounded">
                     <div class="flex items-center">
                         <span class="px-2">すべて見る</span>

--- a/web/resources/views/items/search.blade.php
+++ b/web/resources/views/items/search.blade.php
@@ -4,6 +4,46 @@
         <div>
             <h1 class="PHeading3 border-l-4 p-2 border-blue-500">「@if (isset($keyword)){{ $keyword }}@else{{ $categoryName }}@endif」の備品一覧</h1>
         </div>
+        @if (isset($categoryName) && $categoryName == '新着')
+            <div>
+                <div class="flex items-center pb-3">
+                    <p class="mr-3">カテゴリ：</p>
+                    <ul class="flex items-center">
+                        <li
+                            class="@if ($categoryId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a href="{{ route('items.latestList', ['categoryId' => 0, 'availableId' => 0]) }}">全て</a>
+                        </li>
+                        @foreach ($categories as $category)
+                            <li
+                                class="@if ($categoryId == $category->id) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                                <a
+                                    href="{{ route('items.latestList', ['categoryId' => $category->id, 'availableId' => 0]) }}">{{ $category->name }}</a>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+                <div class="flex items-center">
+                    <p class="mr-3">状態：</p>
+                    <ul class="flex items-center">
+                        <li
+                            class="@if ($availableId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.latestList', ['categoryId' => $categoryId, 'availableId' => 0]) }}">全て</a>
+                        </li>
+                        <li
+                            class="@if ($availableId == 1) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.latestList', ['categoryId' => $categoryId, 'availableId' => 1]) }}">利用可能</a>
+                        </li>
+                        <li
+                            class="@if ($availableId == 2) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.latestList', ['categoryId' => $categoryId, 'availableId' => 2]) }}">利用中</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        @endif
         <h2><span class="font-bold">{{ $items->total() }}</span>件見つかりました</h2>
     </div>
     <div class="h-full px-8 sm:px-12 lg:px-24">

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -54,7 +54,7 @@ Route::middleware(['auth'])->group(function () {
 Route::prefix('items')->group(function () {
     Route::get('search/{keyword?}', [ItemController::class, 'result'])->name('items.result');
     Route::get('category/{categoryId?}', [ItemController::class, 'categoryList'])->name('items.categoryList');
-    Route::get('latest/list', [ItemController::class, 'latestList'])->name('items.latestList');
+    Route::get('latest/{categoryId?}/{availableId?}', [ItemController::class, 'latestList'])->name('items.latestList');
 });
 
 Route::get('/', [DashboardController::class, 'index'])->name('dashboard');

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -55,9 +55,9 @@ Route::middleware(['auth'])->group(function () {
 });
 
 Route::prefix('items')->group(function () {
-    Route::get('search/{keyword?}', [ItemController::class, 'result'])->name('items.result');
-    Route::get('category/{categoryId?}', [ItemController::class, 'categoryList'])->name('items.categoryList');
-    Route::get('latest/{categoryId?}/{availableId?}', [ItemController::class, 'latestList'])->name('items.latestList');
+    Route::get('search/{keyword}', [ItemController::class, 'result'])->name('items.result');
+    Route::get('category/{categoryId}', [ItemController::class, 'categoryList'])->name('items.categoryList');
+    Route::get('latest/{categoryId}/{availableId}', [ItemController::class, 'latestList'])->name('items.latestList');
 });
 
 Route::get('/', [DashboardController::class, 'index'])->name('dashboard');


### PR DESCRIPTION
## 関連イシュー
#8

## 🚨🚨🚨🚨🚨🚨追加実装🚨🚨🚨🚨🚨🚨
本プルリクでは新着時のみフィルター機能をつけていますが、他の画面ではそれぞれ以下のプルリクで実装しております。分かれてしまっていて申し訳ございません🙇‍♂️
また、以下の3つは並び替え機能（#9）のイシューに取り組んだ後に作成したため、フィルターと一緒に並び替え機能も実装しています。

- キーワード検索
https://github.com/posse-ap/posse1-hackathon-202209-team1A/pull/65
- もうすぐ利用可能
https://github.com/posse-ap/posse1-hackathon-202209-team1A/pull/61
- カテゴリ
https://github.com/posse-ap/posse1-hackathon-202209-team1A/pull/70

## 検証したこと
- 新着もっと見るの時、フィルタが表示されるか
- カテゴリ、状態でそれぞれで絞り込みが可能か

## エビデンス
- 新着もっと見るを押下時（初期状態）
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/74804252/189021398-dbf3a811-5c97-4be9-889c-30f9e06380e6.png">

- カテゴリ「書籍：技術書」を選択時
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/74804252/189021494-c3daf936-3d1b-4055-9447-3e935866f50a.png">

- 状態「利用可能」を選択時
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189021552-24b4c65f-1c62-49ff-8ecd-171a82cfcbcc.png">