### PR TITLE
カテゴリを全て表示

### DIFF
--- a/web/app/Models/Category.php
+++ b/web/app/Models/Category.php
@@ -23,7 +23,7 @@ class Category extends Model
      */
     public static function findCategoriesWithItem(): Collection
     {
-        $categories = self::latest()->with('items')->get();
+        $categories = self::with('items')->get();
 
         return $categories->filter(function ($value, $key) {
             return count($value->items->where('is_public', true)) > 0;

--- a/web/database/seeders/CategorySeeder.php
+++ b/web/database/seeders/CategorySeeder.php
@@ -23,6 +23,7 @@ class CategorySeeder extends Seeder
             ['name' => 'PC用品', 'created_at' => "2022-05-15"],
             ['name' => '書籍：小説', 'created_at' => "2022-04-15"],
             ['name' => '書籍：漫画', 'created_at' => "2022-05-15"],
+            ['name' => '文具', 'created_at' => "2022-05-15"],
         ];
 
         Category::insert($data);

--- a/web/database/seeders/ItemSeeder.php
+++ b/web/database/seeders/ItemSeeder.php
@@ -109,6 +109,14 @@ class ItemSeeder extends Seeder
                 'is_public' => true,
                 'provider' => '株式会社アンチパターン',
             ],
+            [
+                'category_id' => 7,
+                'name' => 'ペン',
+                'image_path' => $path,
+                'available_days' => 14,
+                'is_public' => true,
+                'provider' => '株式会社アンチパターン',
+            ],
         ];
 
         Item::insert($data);

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -48,7 +48,7 @@
             </div>
         </div>
 
-        @if (count($commingSoonItems)>0)
+        @if (count($commingSoonItems) > 0)
             <div class="py-12 text-center">
                 <h2 class="text-2xl font-bold py-6">もうすぐ利用できます</h2>
                 <div class="flex py-4">
@@ -71,26 +71,24 @@
         @endif
 
         @foreach ($categoryItems as $category)
-            @if ($loop->index < $displayLimit)
-                <div class="py-12 text-center">
-                    <h2 class="text-2xl font-bold py-6">{{ $category->name }}</h2>
-                    <div class="flex py-4">
-                        @foreach ($category->items as $key => $item)
-                            @if ($key < $displayLimit)
-                                <x-item-card :item="$item"></x-item-card>
-                            @endif
-                        @endforeach
-                    </div>
-                    <div>
-                        <a href="{{ route('items.categoryList', ['categoryId' => $category->id]) }}"
-                            class="inline-block bg-transparent hover:bg-gray-100 text-gray-500 font-semibold py-2 px-6 border border-gray-500 rounded">
-                            <div class="flex items-center">
-                                <span class="px-2">すべて見る</span>
-                                <x-codicon-triangle-down class="inline-block w-5 h-5" />
-                            </div>
-                        </a>
-                    </div>
-            @endif
+            <div class="py-12 text-center">
+                <h2 class="text-2xl font-bold py-6">{{ $category->name }}</h2>
+                <div class="flex py-4">
+                    @foreach ($category->items as $key => $item)
+                        @if ($key < $displayLimit)
+                            <x-item-card :item="$item"></x-item-card>
+                        @endif
+                    @endforeach
+                </div>
+                <div>
+                    <a href="{{ route('items.categoryList', ['categoryId' => $category->id]) }}"
+                        class="inline-block bg-transparent hover:bg-gray-100 text-gray-500 font-semibold py-2 px-6 border border-gray-500 rounded">
+                        <div class="flex items-center">
+                            <span class="px-2">すべて見る</span>
+                            <x-codicon-triangle-down class="inline-block w-5 h-5" />
+                        </div>
+                    </a>
+                </div>
         @endforeach
     </div>
 </x-guest-layout>


### PR DESCRIPTION
## 関連イシュー
#21, #63
#57 のPRを修正

## 検証したこと
データの作成日付でなくレコード順に表示
5つ以上のカテゴリがあっても表示できる

## エビデンス
データ
<img width="314" alt="スクリーンショット 2022-09-08 17 44 50" src="https://user-images.githubusercontent.com/74808471/189077740-abf41d7d-52c8-4861-99fe-909803c9cadc.png">
作成日付でなくレコード順になっている
<img width="761" alt="スクリーンショット 2022-09-08 17 45 42" src="https://user-images.githubusercontent.com/74808471/189077933-41a2cda2-8459-4a32-bbcc-704a662fb144.png">

5つ以上のカテゴリを表示できる。
<img width="411" alt="スクリーンショット 2022-09-08 17 46 30" src="https://user-images.githubusercontent.com/74808471/189078097-de9b5f20-aa49-4b55-907c-41ae958e73d8.png">

