### PR TITLE
#62 キーワード検索時にもフィルターが機能するように変更

### DIFF
--- a/web/public/css/app.css
+++ b/web/public/css/app.css
@@ -775,6 +775,12 @@ select {
 .left-2 {
   left: 0.5rem;
 }
+.top-0 {
+  top: 0px;
+}
+.right-0 {
+  right: 0px;
+}
 .left-0 {
   left: 0px;
 }
@@ -784,13 +790,13 @@ select {
 .z-50 {
   z-index: 50;
 }
-.mx-auto {
-  margin-left: auto;
-  margin-right: auto;
-}
 .mx-4 {
   margin-left: 1rem;
   margin-right: 1rem;
+}
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
 }
 .my-10 {
   margin-top: 2.5rem;
@@ -817,6 +823,9 @@ select {
 .mt-20 {
   margin-top: 5rem;
 }
+.mt-5 {
+  margin-top: 1.25rem;
+}
 .mb-4 {
   margin-bottom: 1rem;
 }
@@ -829,17 +838,8 @@ select {
 .mr-8 {
   margin-right: 2rem;
 }
-.mb-4 {
-  margin-bottom: 1rem;
-}
 .ml-2 {
   margin-left: 0.5rem;
-}
-.mt-3 {
-  margin-top: 0.75rem;
-}
-.mt-5 {
-  margin-top: 1.25rem;
 }
 .mt-4 {
   margin-top: 1rem;
@@ -852,6 +852,9 @@ select {
 }
 .mr-3 {
   margin-right: 0.75rem;
+}
+.mt-3 {
+  margin-top: 0.75rem;
 }
 .ml-12 {
   margin-left: 3rem;
@@ -879,18 +882,6 @@ select {
 }
 .mr-5 {
   margin-right: 1.25rem;
-}
-.mt-1 {
-  margin-top: 0.25rem;
-}
-.mt-2 {
-  margin-top: 0.5rem;
-}
-.ml-1 {
-  margin-left: 0.25rem;
-}
-.-mr-2 {
-  margin-right: -0.5rem;
 }
 .block {
   display: block;
@@ -934,6 +925,9 @@ select {
 .h-16 {
   height: 4rem;
 }
+.h-8 {
+  height: 2rem;
+}
 .h-20 {
   height: 5rem;
 }
@@ -942,9 +936,6 @@ select {
 }
 .min-h-screen {
   min-height: 100vh;
-}
-.h-4 {
-  height: 1rem;
 }
 .w-5 {
   width: 1.25rem;
@@ -990,12 +981,6 @@ select {
 .w-auto {
   width: auto;
 }
-.w-auto {
-  width: auto;
-}
-.w-4 {
-  width: 1rem;
-}
 .w-1\/12 {
   width: 8.333333%;
 }
@@ -1010,9 +995,6 @@ select {
 }
 .max-w-6xl {
   max-width: 72rem;
-}
-.w-auto {
-  width: auto;
 }
 .max-w-7xl {
   max-width: 80rem;
@@ -1165,12 +1147,6 @@ select {
 .border-b-4 {
   border-bottom-width: 4px;
 }
-.border-b {
-  border-bottom-width: 1px;
-}
-.border-t {
-  border-top-width: 1px;
-}
 .border-gray-300 {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
@@ -1249,6 +1225,9 @@ select {
 .p-2 {
   padding: 0.5rem;
 }
+.p-6 {
+  padding: 1.5rem;
+}
 .px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
@@ -1309,25 +1288,17 @@ select {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
 }
-.px-10 {
-  padding-left: 2.5rem;
-  padding-right: 2.5rem;
-}
-.py-8 {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
-}
 .pt-8 {
   padding-top: 2rem;
 }
 .pb-8 {
   padding-bottom: 2rem;
 }
-.pt-6 {
-  padding-top: 1.5rem;
-}
 .pt-5 {
   padding-top: 1.25rem;
+}
+.pt-6 {
+  padding-top: 1.5rem;
 }
 .pb-2 {
   padding-bottom: 0.5rem;
@@ -1410,14 +1381,14 @@ select {
 .leading-tight {
   line-height: 1.25;
 }
-.tracking-widest {
-  letter-spacing: 0.1em;
-}
-.tracking-wider {
-  letter-spacing: 0.05em;
+.leading-7 {
+  line-height: 1.75rem;
 }
 .tracking-wide {
   letter-spacing: 0.025em;
+}
+.tracking-wider {
+  letter-spacing: 0.05em;
 }
 .tracking-widest {
   letter-spacing: 0.1em;
@@ -1430,17 +1401,13 @@ select {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
-.text-blue-600 {
+.text-green-600 {
   --tw-text-opacity: 1;
-  color: rgb(37 99 235 / var(--tw-text-opacity));
+  color: rgb(22 163 74 / var(--tw-text-opacity));
 }
 .text-red-500 {
   --tw-text-opacity: 1;
   color: rgb(239 68 68 / var(--tw-text-opacity));
-}
-.text-green-600 {
-  --tw-text-opacity: 1;
-  color: rgb(22 163 74 / var(--tw-text-opacity));
 }
 .text-lime-800 {
   --tw-text-opacity: 1;
@@ -1478,18 +1445,6 @@ select {
   --tw-text-opacity: 1;
   color: rgb(209 213 219 / var(--tw-text-opacity));
 }
-.text-red-600 {
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity));
-}
-.text-gray-900 {
-  --tw-text-opacity: 1;
-  color: rgb(17 24 39 / var(--tw-text-opacity));
-}
-.text-indigo-700 {
-  --tw-text-opacity: 1;
-  color: rgb(67 56 202 / var(--tw-text-opacity));
-}
 .text-gray-400 {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
@@ -1501,6 +1456,10 @@ select {
 .text-gray-800 {
   --tw-text-opacity: 1;
   color: rgb(31 41 55 / var(--tw-text-opacity));
+}
+.text-blue-600 {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity));
 }
 .underline {
   -webkit-text-decoration-line: underline;
@@ -1848,11 +1807,6 @@ select {
   .lg\:px-8 {
     padding-left: 2rem;
     padding-right: 2rem;
-  }
-
-  .lg\:px-32 {
-    padding-left: 8rem;
-    padding-right: 8rem;
   }
 }
 

--- a/web/public/mix-manifest.json
+++ b/web/public/mix-manifest.json
@@ -1,4 +1,5 @@
 {
     "/js/app.js": "/js/app.js",
+    "/js/main.js": "/js/main.js",
     "/css/app.css": "/css/app.css"
 }

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -20,10 +20,10 @@
             </form>
             <div class="flex text-white whitespace-nowrap mt-4">
                 <p>キーワード：</p>
-                <a href="{{ route('items.result', ['keyword' => 'Go言語']) }}" class="block mr-3">Go言語</a>
-                <a href="{{ route('items.result', ['keyword' => 'Rust']) }}" class="block mr-3">Rust</a>
-                <a href="{{ route('items.result', ['keyword' => 'スクラム']) }}" class="block mr-3">スクラム</a>
-                <a href="{{ route('items.result', ['keyword' => 'Laravel']) }}" class="block mr-3">Laravel</a>
+                <a href="{{ route('items.result', ['keyword' => 'Go言語', 'categoryId' => 0, 'availableId' => 0, 'sortId' => 0]) }}" class="block mr-3">Go言語</a>
+                <a href="{{ route('items.result', ['keyword' => 'Rust', 'categoryId' => 0, 'availableId' => 0, 'sortId' => 0]) }}" class="block mr-3">Rust</a>
+                <a href="{{ route('items.result', ['keyword' => 'スクラム', 'categoryId' => 0, 'availableId' => 0, 'sortId' => 0]) }}" class="block mr-3">スクラム</a>
+                <a href="{{ route('items.result', ['keyword' => 'Laravel', 'categoryId' => 0, 'availableId' => 0, 'sortId' => 0]) }}" class="block mr-3">Laravel</a>
             </div>
         </div>
     </div>

--- a/web/resources/views/items/search.blade.php
+++ b/web/resources/views/items/search.blade.php
@@ -2,9 +2,7 @@
 
     <div class="grid grid-cols-1 gap-8 mt-8 px-0 md:px-32">
         <div>
-            <h1 class="PHeading3 border-l-4 p-2 border-blue-500">「@if (isset($keyword))
-                    {{ $keyword }}@else{{ $categoryName }}
-                @endif」の備品一覧</h1>
+            <h1 class="PHeading3 border-l-4 p-2 border-blue-500">「@if (isset($keyword)){{ $keyword }}@else{{ $categoryName }}@endif」の備品一覧</h1>
         </div>
         @if (isset($categoryName) && $categoryName == '新着')
             <div>
@@ -112,6 +110,61 @@
                             class="@if ($sortId == 1) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
                             <a
                                 href="{{ route('items.commingSoonList', ['categoryId' => $categoryId, 'availableId' => $availableId, 'sortId' => 1]) }}">人気順</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        @elseif (isset($keyword))
+            <div>
+                <div class="flex items-center pb-3">
+                    <p class="mr-3">カテゴリ：</p>
+                    <ul class="flex items-center">
+                        <li
+                            class="@if ($categoryId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.result', ['keyword' => $keyword, 'categoryId' => 0, 'availableId' => 0, 'sortId' => 0]) }}">全て</a>
+                        </li>
+                        @foreach ($categories as $category)
+                            <li
+                                class="@if ($categoryId == $category->id) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                                <a
+                                    href="{{ route('items.result', ['keyword' => $keyword, 'categoryId' => $category->id, 'availableId' => 0, 'sortId' => 0]) }}">{{ $category->name }}</a>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+                <div class="flex items-center pb-3">
+                    <p class="mr-3">状態：</p>
+                    <ul class="flex items-center">
+                        <li
+                            class="@if ($availableId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.result', ['keyword' => $keyword, 'categoryId' => $categoryId, 'availableId' => 0, 'sortId' => 0]) }}">全て</a>
+                        </li>
+                        <li
+                            class="@if ($availableId == 1) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.result', ['keyword' => $keyword, 'categoryId' => $categoryId, 'availableId' => 1, 'sortId' => 0]) }}">利用可能</a>
+                        </li>
+                        <li
+                            class="@if ($availableId == 2) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.result', ['keyword' => $keyword, 'categoryId' => $categoryId, 'availableId' => 2, 'sortId' => 0]) }}">利用中</a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="flex items-center pb-3">
+                    <p class="mr-3">並び順：</p>
+                    <ul class="flex items-center">
+                        <li
+                            class="@if ($sortId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.result', ['keyword' => $keyword, 'categoryId' => $categoryId, 'availableId' => $availableId, 'sortId' => 0]) }}">新着順</a>
+                        </li>
+                        <li
+                            class="@if ($sortId == 1) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.result', ['keyword' => $keyword, 'categoryId' => $categoryId, 'availableId' => $availableId, 'sortId' => 1]) }}">人気順</a>
                         </li>
                     </ul>
                 </div>

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -55,7 +55,7 @@ Route::middleware(['auth'])->group(function () {
 });
 
 Route::prefix('items')->group(function () {
-    Route::get('search/{keyword}', [ItemController::class, 'result'])->name('items.result');
+    Route::get('search/{keyword}/{categoryId}/{availableId}/{sortId}', [ItemController::class, 'result'])->name('items.result');
     Route::get('category/{categoryId}', [ItemController::class, 'categoryList'])->name('items.categoryList');
     Route::get('latest/{categoryId}/{availableId}/{sortId}', [ItemController::class, 'latestList'])->name('items.latestList');
     Route::get('commingSoon/{categoryId}/{availableId}/{sortId}', [ItemController::class, 'commingSoonList'])->name('items.commingSoonList');


### PR DESCRIPTION
## 関連イシュー
#8、#18
🚨[以前のプルリク](https://github.com/posse-ap/posse1-hackathon-202209-team1A/pull/56)ではキーワード検索ではフィルターボタンを付けなかったため追加しました。

## 検証したこと
- キーワード検索した時に、フィルターボタンが表示されるか
- 用意されたキーワードで検索したときにフィルターボタンが表示されるか
- 検索結果からさらに絞り込み、並び替えができるか

## エビデンス
- goで検索時の表示
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189077569-f5768376-911d-4e89-9679-082df2829cf0.png">

- 技術書、利用可能で絞り込み
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189078038-20eebadc-6cb2-4438-84a0-ea4aa21f3804.png">
