### PR TITLE
#68 カテゴリでのフィルタ機能

### DIFF
--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -117,13 +117,78 @@ class ItemController extends Controller
         return view('items.search', compact('items', 'keyword', 'categoryId', 'availableId', 'sortId', 'categories'));
     }
 
-    public function categoryList($categoryId)
+    public function categoryList($categoryId, $availableId, $sortId)
     {
-        $items = Item::where('category_id', $categoryId)->where('is_public', true)->paginate(10);
-        $categoryName = Category::find($categoryId)->name;
+        $categories = Category::all();
         $keyword = null;
 
-        return view('items.search', compact('items', 'categoryName', 'keyword'));
+        if ($categoryId != 0) {
+            $categoryName = Category::find($categoryId)->name;
+
+            if ($availableId == 0) {
+                if ($sortId == 0) {
+                    $items = Item::where('is_public', true)->where('category_id', $categoryId)->orderBy('created_at', 'desc')->paginate(10);
+                } else {
+                    $items = Item::where('is_public', true)->where('category_id', $categoryId)->withCount('usageHistories')->orderBy('usage_histories_count', 'desc')->paginate(10);
+                }
+            } elseif ($availableId == 1) {
+                if ($sortId == 0) {
+                    $items = Item::where('is_public', true)->where('category_id', $categoryId)->whereDoesntHave('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })
+                        ->orderBy('created_at', 'desc')->paginate(10);
+                } else {
+                    $items = Item::where('is_public', true)->where('category_id', $categoryId)->whereDoesntHave('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })->withCount('usageHistories')->orderBy('usage_histories_count', 'desc')->paginate(10);
+                }
+            } else {
+                if ($sortId == 0) {
+                    $items = Item::where('is_public', true)->where('category_id', $categoryId)->whereHas('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })
+                        ->orderBy('created_at', 'desc')->paginate(10);
+                } else {
+                    $items = Item::where('is_public', true)->where('category_id', $categoryId)->whereHas('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })->withCount('usageHistories')->orderBy('usage_histories_count', 'desc')->paginate(10);
+                }
+            }
+        } else {
+            $categoryName = "全て";
+
+            if ($availableId == 0) {
+                if ($sortId == 0) {
+                    $items = Item::where('is_public', true)->orderBy('created_at', 'desc')->paginate(10);
+                } else {
+                    $items = Item::where('is_public', true)->withCount('usageHistories')->orderBy('usage_histories_count', 'desc')->paginate(10);
+                }
+            } elseif ($availableId == 1) {
+                if ($sortId == 0) {
+                    $items = Item::where('is_public', true)->whereDoesntHave('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })
+                        ->orderBy('created_at', 'desc')->paginate(10);
+                } else {
+                    $items = Item::where('is_public', true)->whereDoesntHave('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })->withCount('usageHistories')->orderBy('usage_histories_count', 'desc')->paginate(10);
+                }
+            } else {
+                if ($sortId == 0) {
+                    $items = Item::where('is_public', true)->whereHas('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })
+                        ->orderBy('created_at', 'desc')->paginate(10);
+                } else {
+                    $items = Item::where('is_public', true)->whereHas('usageHistories', function ($query) {
+                        $query->where('is_returned', false);
+                    })->withCount('usageHistories')->orderBy('usage_histories_count', 'desc')->paginate(10);
+                }
+            }
+        }
+
+        return view('items.search', compact('items', 'categoryName', 'keyword', 'categoryId', 'availableId', 'sortId', 'categories'));
     }
 
     public function latestList($categoryId, $availableId, $sortId)

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -98,7 +98,7 @@
                 @endforeach
             </div>
             <div>
-                <a href="{{ route('items.categoryList', ['categoryId' => $category->id]) }}"
+                <a href="{{ route('items.categoryList', ['categoryId' => $category->id, 'availableId' => 0, 'sortId' => 0]) }}"
                     class="inline-block bg-transparent hover:bg-gray-100 text-gray-500 font-semibold py-2 px-6 border border-gray-500 rounded">
                     <div class="flex items-center">
                         <span class="px-2">すべて見る</span>

--- a/web/resources/views/items/search.blade.php
+++ b/web/resources/views/items/search.blade.php
@@ -2,9 +2,7 @@
 
     <div class="grid grid-cols-1 gap-8 mt-8 px-0 md:px-32">
         <div>
-            <h1 class="PHeading3 border-l-4 p-2 border-blue-500">「@if (isset($keyword))
-                    {{ $keyword }}@else{{ $categoryName }}
-                @endif」の備品一覧</h1>
+            <h1 class="PHeading3 border-l-4 p-2 border-blue-500">「@if (isset($keyword)){{ $keyword }}@else{{ $categoryName }}@endif」の備品一覧</h1>
         </div>
         @if (isset($categoryName) && $categoryName == '新着')
             <div>
@@ -171,6 +169,61 @@
                     </ul>
                 </div>
             </div>
+        @elseif (isset($categoryName))
+        <div>
+            <div class="flex items-center pb-3">
+                <p class="mr-3">カテゴリ：</p>
+                <ul class="flex items-center">
+                    <li
+                        class="@if ($categoryId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                        <a
+                            href="{{ route('items.categoryList', ['categoryId' => 0, 'availableId' => 0, 'sortId' => 0]) }}">全て</a>
+                    </li>
+                    @foreach ($categories as $category)
+                        <li
+                            class="@if ($categoryId == $category->id) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                            <a
+                                href="{{ route('items.categoryList', ['categoryId' => $category->id, 'availableId' => 0, 'sortId' => 0]) }}">{{ $category->name }}</a>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+            <div class="flex items-center pb-3">
+                <p class="mr-3">状態：</p>
+                <ul class="flex items-center">
+                    <li
+                        class="@if ($availableId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                        <a
+                            href="{{ route('items.categoryList', ['categoryId' => $categoryId, 'availableId' => 0, 'sortId' => 0]) }}">全て</a>
+                    </li>
+                    <li
+                        class="@if ($availableId == 1) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                        <a
+                            href="{{ route('items.categoryList', ['categoryId' => $categoryId, 'availableId' => 1, 'sortId' => 0]) }}">利用可能</a>
+                    </li>
+                    <li
+                        class="@if ($availableId == 2) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                        <a
+                            href="{{ route('items.categoryList', ['categoryId' => $categoryId, 'availableId' => 2, 'sortId' => 0]) }}">利用中</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="flex items-center pb-3">
+                <p class="mr-3">並び順：</p>
+                <ul class="flex items-center">
+                    <li
+                        class="@if ($sortId == 0) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                        <a
+                            href="{{ route('items.categoryList', ['categoryId' => $categoryId, 'availableId' => $availableId, 'sortId' => 0]) }}">新着順</a>
+                    </li>
+                    <li
+                        class="@if ($sortId == 1) PButton-primary-mini @else PButton-gray-mini @endif mr-3">
+                        <a
+                            href="{{ route('items.categoryList', ['categoryId' => $categoryId, 'availableId' => $availableId, 'sortId' => 1]) }}">人気順</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
         @endif
         <h2><span class="font-bold">{{ $items->total() }}</span>件見つかりました</h2>
     </div>

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -57,7 +57,7 @@ Route::middleware(['auth'])->group(function () {
 
 Route::prefix('items')->group(function () {
     Route::get('search/{keyword}/{categoryId}/{availableId}/{sortId}', [ItemController::class, 'result'])->name('items.result');
-    Route::get('category/{categoryId}', [ItemController::class, 'categoryList'])->name('items.categoryList');
+    Route::get('category/{categoryId}/{availableId}/{sortId}', [ItemController::class, 'categoryList'])->name('items.categoryList');
     Route::get('latest/{categoryId}/{availableId}/{sortId}', [ItemController::class, 'latestList'])->name('items.latestList');
     Route::get('commingSoon/{categoryId}/{availableId}/{sortId}', [ItemController::class, 'commingSoonList'])->name('items.commingSoonList');
 });


### PR DESCRIPTION
## 関連イシュー
#68 #8
🚨[以前のプルリク](https://github.com/posse-ap/posse1-hackathon-202209-team1A/pull/56)ではキーワード検索ではフィルターボタンを付けなかったため追加しました。

## 検証したこと
- ダッシュボードに存在するカテゴリごとの「全て見る」をクリックした時に、それぞれのカテゴリが絞り込まれて表示されるか
- フィルタのボタンが表示されるか・機能するか
- 並び順で並び替えが可能か

## エビデンス
- 「書籍：技術書」の全て見るをクリックした時の表示
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189116501-38630a0f-f5f0-4ef9-939e-377ceb6d1c19.png">

- 利用可能のみを絞り込み
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189116699-d58d1f59-d68d-412c-bac2-e89aac671750.png">

- 「書籍：技術書」を人気順に並び替え
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189116613-f0dbcabc-d0f8-417f-a8a0-79b3cf64ec9f.png">

- 「書籍：漫画」クリック
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189116844-ab8594bc-da07-4849-8ec3-555cfbc70134.png">
