### PR TITLE
#74 備品詳細画面 利用状況を追加

### DIFF
--- a/web/database/seeders/UsageHistorySeeder.php
+++ b/web/database/seeders/UsageHistorySeeder.php
@@ -109,7 +109,7 @@ class UsageHistorySeeder extends Seeder
                 'item_id' => 4,
                 'is_returned' => false,
                 'start_at' => "2022-09-05",
-                'return_at' => "2022-09-10",
+                'return_at' => "2022-09-06",
                 'created_at' => "2022-09-15",
             ],
             [

--- a/web/resources/views/items/show.blade.php
+++ b/web/resources/views/items/show.blade.php
@@ -123,6 +123,10 @@
                             <td class="px-4 py-2">{{ $item->category->name ?? '' }}</td>
                         </tr>
                         <tr>
+                            <td class="px-4 py-2 font-bold">状態</td>
+                            <td class="px-4 py-2">@if($item->is_borrowed())利用中 @else 利用可能 @endif</td>
+                        </tr>
+                        <tr>
                             <td class="px-4 py-2 font-bold">登録日時</td>
                             <td class="px-4 py-2">{{ $item->created_at }}</td>
                         </tr>


### PR DESCRIPTION
## 関連イシュー
#74 
元々のイシュー： #15 

## 検証したこと
- 右下に利用状況が正しく記載されるかどうか

## エビデンス
- 自分が利用中の時
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189151560-0051aedb-74da-4598-8d39-cd55e9f39e5a.png">

- 他の人が利用中の時
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189151680-ad4ccbda-d003-4daa-8f32-a5f84baa8f4c.png">

- 誰も利用していない時
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/74804252/189151768-0cd1040d-d192-460f-b491-a3c182790449.png">